### PR TITLE
Added information element "Bearer control mode".

### DIFF
--- a/gtp/gtpie.c
+++ b/gtp/gtpie.c
@@ -243,7 +243,8 @@ int gtpie_decaps(union gtpie_member *ie[], int version, void *pack,
 		case GTPIE_RP_SMS:
 		case GTPIE_RP:
 		case GTPIE_MS_NOT_REACH:
-			if (j < GTPIE_SIZE) {
+		case GTPIE_BCM:
+      if (j < GTPIE_SIZE) {
 				ie[j] = (union gtpie_member *)p;
 				if (GTPIE_DEBUG)
 					printf
@@ -457,7 +458,8 @@ int gtpie_encaps(union gtpie_member *ie[], void *pack, unsigned *len)
 			case GTPIE_RP_SMS:
 			case GTPIE_RP:
 			case GTPIE_MS_NOT_REACH:
-				iesize = 2;
+			case GTPIE_BCM:
+        iesize = 2;
 				break;
 			case GTPIE_FL_DI:	/* TV GTPIE types with value length 2 */
 			case GTPIE_FL_C:
@@ -558,7 +560,8 @@ int gtpie_encaps2(union gtpie_member ie[], unsigned int size,
 				case GTPIE_RP_SMS:
 				case GTPIE_RP:
 				case GTPIE_MS_NOT_REACH:
-					iesize = 2;
+				case GTPIE_BCM:
+          iesize = 2;
 					break;
 				case GTPIE_PFI:	/* TV GTPIE types with value length 2 */
 				case GTPIE_CHARGING_C:

--- a/gtp/gtpie.h
+++ b/gtp/gtpie.h
@@ -106,6 +106,7 @@ static __inline uint64_t hton64(uint64_t q)
 #define GTPIE_USER_LOC      152	/* User Location Information  */
 #define GTPIE_MS_TZ         153	/* MS Time Zone */
 #define GTPIE_IMEI_SV       154	/* IMEI Software Version */
+#define GTPIE_BCM           184	/* Bearer control mode */
 /* 239-250 Reserved for the GPRS charging protocol (see GTP' in GSM 12.15) */
 #define GTPIE_CHARGING_ADDR 251	/* Charging Gateway Address */
 /* 252-254 Reserved for the GPRS charging protocol (see GTP' in GSM 12.15) */


### PR DESCRIPTION
Latest Cisco GGSN sends this in response to "Create PDP context" request to SGSN emulator.
Without this SGSN emulator doesn't work with Cisco GGSN.
